### PR TITLE
Conditionally define NETWORK_CONTROLLER

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -22,7 +22,9 @@
 //#define _DUMP_HEADER
 //#define _DUMP_FRAME_DATA
 
-#define NETWORK_CONTROLLER ETHERNET_CONTROLLER_W5X00
+#ifndef NETWORK_CONTROLLER
+#  define NETWORK_CONTROLLER ETHERNET_CONTROLLER_W5X00
+#endif
 
 /** Maximum size of data buffer - frame payload (in bytes). */
 constexpr uint16_t kBufferMaxSize{ 256 };


### PR DESCRIPTION
The macro NETWORK_CONTROLLER should only be defined if it hasn't been defined before. Currently you'd have to change the library config.h code to use a different network controller. With this change the macro can be defined in the user space (.ino sketch possibly) and thus you do not have to fiddle with library code.