### PR TITLE
Support for case insensitive HTTP Headers

### DIFF
--- a/src/WebSocketClient.cpp
+++ b/src/WebSocketClient.cpp
@@ -150,7 +150,7 @@ bool WebSocketClient::_readResponse() {
           // [2] Upgrade header:
           //
 
-          if (strcmp_P(header, (PGM_P)F("Upgrade")) == 0) {
+          if (strcasecmp_P(header, (PGM_P)F("Upgrade")) == 0) {
             value = strtok_r(rest, " ", &rest);
             if (!value || (strcasecmp_P(value, (PGM_P)F("websocket")) != 0)) {
               __debugOutput(F("Error during WebSocket handshake: 'Upgrade' "
@@ -167,9 +167,9 @@ bool WebSocketClient::_readResponse() {
           // [3] Connection header:
           //
 
-          else if (strcmp_P(header, (PGM_P)F("Connection")) == 0) {
+          else if (strcasecmp_P(header, (PGM_P)F("Connection")) == 0) {
             value = strtok_r(rest, " ", &rest);
-            if (!value || (strcmp_P(value, (PGM_P)F("Upgrade")) != 0)) {
+            if (!value || (strcasecmp_P(value, (PGM_P)F("Upgrade")) != 0)) {
               __debugOutput(
                 F("Error during WebSocket handshake: 'Connection' header "
                   "value is not 'Upgrade': %s\n"),
@@ -185,7 +185,7 @@ bool WebSocketClient::_readResponse() {
           // [4] Sec-WebSocket-Accept header:
           //
 
-          else if (strcmp_P(header, (PGM_P)F("Sec-WebSocket-Accept")) == 0) {
+          else if (strcasecmp_P(header, (PGM_P)F("Sec-WebSocket-Accept")) == 0) {
             value = strtok_r(rest, " ", &rest);
 
             char encodedKey[29]{};

--- a/src/WebSocketServer.cpp
+++ b/src/WebSocketServer.cpp
@@ -179,13 +179,13 @@ bool WebSocketServer::_handleRequest(NetClient &client) {
           //
 
           // #TODO ... or not
-          if (strcmp_P(header, (PGM_P)F("Host")) == 0) {}
+          if (strcasecmp_P(header, (PGM_P)F("Host")) == 0) {}
 
           //
           // [3] Upgrade header:
           //
 
-          else if (strcmp_P(header, (PGM_P)F("Upgrade")) == 0) {
+          else if (strcasecmp_P(header, (PGM_P)F("Upgrade")) == 0) {
             value = strtok_r(rest, " ", &rest);
             if (!value || !_isValidUpgrade(value)) {
               _rejectRequest(client, WebSocketError::BAD_REQUEST);
@@ -199,7 +199,7 @@ bool WebSocketServer::_handleRequest(NetClient &client) {
           // [4] Connection header:
           //
 
-          else if (strcmp_P(header, (PGM_P)F("Connection")) == 0) {
+          else if (strcasecmp_P(header, (PGM_P)F("Connection")) == 0) {
             if (rest && _isValidConnection(rest))
               flags |= kValidConnectionHeader;
           }
@@ -208,7 +208,7 @@ bool WebSocketServer::_handleRequest(NetClient &client) {
           // [5] Sec-WebSocket-Key header:
           //
 
-          else if (strcmp_P(header, (PGM_P)F("Sec-WebSocket-Key")) == 0) {
+          else if (strcasecmp_P(header, (PGM_P)F("Sec-WebSocket-Key")) == 0) {
             value = strtok_r(rest, " ", &rest);
             if (value != nullptr) strcpy(secKey, value);
           }
@@ -217,7 +217,7 @@ bool WebSocketServer::_handleRequest(NetClient &client) {
           // [6] Sec-WebSocket-Version header:
           //
 
-          else if (strcmp_P(header, (PGM_P)F("Sec-WebSocket-Version")) == 0) {
+          else if (strcasecmp_P(header, (PGM_P)F("Sec-WebSocket-Version")) == 0) {
             value = strtok_r(rest, " ", &rest);
             if (!value || !_isValidVersion(atoi(value))) {
               _rejectRequest(client, WebSocketError::BAD_REQUEST);


### PR DESCRIPTION
Per [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) HTTP headers (both keys and values) are case-insensitive. Changing `strcmp_P` to `strcasecmp_P` in `WebSocketClient::_readResponse()` makes it compliant.

I personally had an issue when placing NGINX proxy between a WebSocket client ([mWebSockets](https://github.com/skaarj1989/mWebSockets)) and a WebSocket server ([ws](https://www.npmjs.com/package/ws)) because NGINX normalizes every header (key and value) to be lower case. I suspect that there are many more incompatible WebSocket servers

Note: `strcasecmp_P` was already in use for the Upgrade header value.

The library was tested and the connection was successfully established with the aforementioned NGINX proxy in place. The WebSocket connection should also be working fine as I didn't touch any of it, but I didn't actually test it thoroughly.

I also made analogous changes in WebSocketServer. I did not test it, but **personally** I think it is not necessary and _should_ work fine.