### PR TITLE
Removed WebSocket::read() timeout

### DIFF
--- a/src/WebSocket.cpp
+++ b/src/WebSocket.cpp
@@ -228,16 +228,6 @@ WebSocket::WebSocket(const NetClient &client)
   : m_client(client), m_readyState(ReadyState::OPEN), m_maskEnabled(false) {}
 
 int32_t WebSocket::_read() {
-  const uint32_t timeout{ millis() + kTimeoutInterval };
-  while (!m_client.available() && millis() < timeout) {
-    delay(1);
-  }
-
-  if (millis() > timeout) {
-    close(PROTOCOL_ERROR, true);
-    return -1;
-  }
-
   return m_client.read();
 }
 


### PR DESCRIPTION
I have removed the timeout from the `WebSocket::_read()` function.

This function gets called by `WebSocketClient::listen()`. I think the desired effect is to terminate the connection if nothing is received within `kTimeoutInterval` milliseconds. However I can't find anything regarding such timeout in [RFC6455](https://tools.ietf.org/html/rfc6455) and the only thing that it does _in my experience_ is slow down the overall execution and unexpectadly close the connection. This is because `WebSocketClient::listen()` purpose is to be called once per `loop()` checking for new data and reading that data **only if it actually exists**. There is no specification that guarantees data within a time interval.

IMHO my chages are correct, however I see how this could break some applications that rely on this behaviour. The correct way to implement a timeout is with the [WebSocket Ping](https://tools.ietf.org/html/rfc6455#section-5.5.2) or with any custom ping on top. _Maybe this change should be implemented with a major realease or someway to toggle it in `config.h`?_

Removing the timeout from `WebSocket::_read()` does not break the library (I have production code that has been running for weeks without the timeout).

Btw thanks for the amazing library :smile: 